### PR TITLE
Feat: Add mock email lists to SentScreen, DraftsScreen, TrashScreen, …

### DIFF
--- a/lib/models/email_data.dart
+++ b/lib/models/email_data.dart
@@ -1,0 +1,21 @@
+class EmailData {
+  final String id;
+  final String senderName;
+  final String subject;
+  final String previewText;
+  final String body;
+  final String time;
+  final bool isRead;
+  final List<Map<String, String>> to;
+
+  EmailData({
+    required this.id,
+    required this.senderName,
+    required this.subject,
+    required this.previewText,
+    required this.body,
+    required this.time,
+    required this.isRead,
+    required this.to,
+  });
+}

--- a/lib/screens/drafts/drafts_screen.dart
+++ b/lib/screens/drafts/drafts_screen.dart
@@ -1,14 +1,65 @@
 import 'package:flutter/material.dart';
+import 'package:email_application/models/email_data.dart';
+import 'package:email_application/widgets/email_list_item.dart';
+import 'package:email_application/screens/emails/view_email_screen.dart';
 
 class DraftsScreen extends StatelessWidget {
   const DraftsScreen({super.key});
 
+  static final List<EmailData> mockEmails = [
+    EmailData(
+      id: '1',
+      senderName: 'Bạn',
+      subject: 'Bản nháp: Kế hoạch họp',
+      previewText: 'Gửi kế hoạch họp tuần tới...',
+      body: 'Nội dung bản nháp: Đây là kế hoạch sơ bộ cho cuộc họp tuần tới, cần bổ sung chi tiết.',
+      time: 'Hôm nay',
+      isRead: true,
+      to: [{'displayName': 'Nguyễn Văn A'}, {'displayName': 'Trần Thị B'}],
+    ),
+    EmailData(
+      id: '2',
+      senderName: 'Bạn',
+      subject: 'Bản nháp: Thư mời',
+      previewText: 'Thư mời tham gia sự kiện...',
+      body: 'Nội dung bản nháp: Thư mời tham gia sự kiện công ty, cần chỉnh sửa nội dung.',
+      time: 'Hôm qua',
+      isRead: true,
+      to: [{'displayName': 'Lê Văn C'}],
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text(
-        'Bản nháp',
-        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Bản nháp'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ListView.builder(
+          itemCount: mockEmails.length,
+          itemBuilder: (context, index) {
+            final email = mockEmails[index];
+            return InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ViewEmailScreen(emailData: email),
+                  ),
+                );
+              },
+              child: EmailListItem(
+                senderName: email.senderName,
+                subject: email.subject,
+                previewText: email.previewText,
+                time: email.time,
+                isRead: email.isRead,
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/emails/view_email_screen.dart
+++ b/lib/screens/emails/view_email_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:email_application/models/email_data.dart';
+
+class ViewEmailScreen extends StatelessWidget {
+  final EmailData emailData;
+
+  const ViewEmailScreen({super.key, required this.emailData});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(emailData.subject),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Từ: ${emailData.senderName}',
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Đến: ${emailData.to.map((recipient) => recipient['displayName']).join(', ')}',
+              style: const TextStyle(fontSize: 14, color: Colors.grey),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Thời gian: ${emailData.time}',
+              style: const TextStyle(fontSize: 14, color: Colors.grey),
+            ),
+            const SizedBox(height: 16),
+            const Divider(),
+            Text(
+              emailData.body,
+              style: const TextStyle(fontSize: 16),
+            ),
+            const Spacer(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    // TODO: Logic trả lời
+                  },
+                  child: const Text('Trả lời'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () {
+                    // TODO: Logic chuyển tiếp
+                  },
+                  child: const Text('Chuyển tiếp'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () {
+                    // TODO: Logic xóa
+                  },
+                  child: const Text('Xóa'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/inbox/inbox_screen.dart
+++ b/lib/screens/inbox/inbox_screen.dart
@@ -1,14 +1,76 @@
 import 'package:flutter/material.dart';
+import 'package:email_application/models/email_data.dart';
+import 'package:email_application/widgets/email_list_item.dart';
+import 'package:email_application/screens/emails/view_email_screen.dart';
 
 class InboxScreen extends StatelessWidget {
   const InboxScreen({super.key});
 
+  // Mock data
+  static final List<EmailData> mockEmails = [
+    EmailData(
+      id: '1',
+      senderName: 'Nguyễn Văn A',
+      subject: 'Họp khẩn cấp đội dự án',
+      previewText: 'Chào cả nhóm, chúng ta sẽ có một buổi họp ngắn...',
+      body: 'Nội dung đầy đủ của email họp khẩn cấp: Chúng ta cần thảo luận về tiến độ dự án và phân công nhiệm vụ mới.',
+      time: '9:30 AM',
+      isRead: false,
+      to: [{'displayName': 'Bạn'}],
+    ),
+    EmailData(
+      id: '2',
+      senderName: 'Trần Thị B',
+      subject: 'Chúc mừng sinh nhật!',
+      previewText: 'Chúc bạn một ngày sinh nhật vui vẻ và ý nghĩa!',
+      body: 'Nội dung đầy đủ của email chúc mừng sinh nhật: Chúc bạn một năm mới tràn đầy sức khỏe và thành công!',
+      time: 'Hôm qua',
+      isRead: true,
+      to: [{'displayName': 'Bạn'}],
+    ),
+    EmailData(
+      id: '3',
+      senderName: 'Lê Văn C',
+      subject: 'Báo cáo tuần',
+      previewText: 'Báo cáo tuần này đã được gửi, vui lòng xem xét...',
+      body: 'Nội dung đầy đủ: Báo cáo tuần này bao gồm các cập nhật về tiến độ phát triển ứng dụng email.',
+      time: 'Thứ Hai',
+      isRead: false,
+      to: [{'displayName': 'Bạn'}],
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text(
-        'Hộp thư đến',
-        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Hộp thư đến'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ListView.builder(
+          itemCount: mockEmails.length,
+          itemBuilder: (context, index) {
+            final email = mockEmails[index];
+            return InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ViewEmailScreen(emailData: email),
+                  ),
+                );
+              },
+              child: EmailListItem(
+                senderName: email.senderName,
+                subject: email.subject,
+                previewText: email.previewText,
+                time: email.time,
+                isRead: email.isRead,
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,8 +1,8 @@
-import 'package:email_application/screens/drafts/drafts_screen.dart';
+import 'package:flutter/material.dart';
 import 'package:email_application/screens/inbox/inbox_screen.dart';
 import 'package:email_application/screens/sent/sent_screen.dart';
+import 'package:email_application/screens/drafts/drafts_screen.dart';
 import 'package:email_application/screens/trash/trash_screen.dart';
-import 'package:flutter/material.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -12,41 +12,53 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> {
-  int _selectedIndex = 0;
+  int _currentIndex = 0;
 
-  // Danh sách các màn hình tương ứng với các tab
-  static const List<Widget> _screens = [
-    InboxScreen(),
-    SentScreen(),
-    DraftsScreen(),
-    TrashScreen(),
+  final List<Widget> _screens = [
+    const InboxScreen(),
+    const SentScreen(),
+    const DraftsScreen(),
+    const TrashScreen(),
   ];
-
-  void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('TVA Email')),
-      body: IndexedStack(index: _selectedIndex, children: _screens),
-      bottomNavigationBar: BottomNavigationBar(
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.inbox),
-            label: 'Hộp thư đến',
+      appBar: AppBar(
+        title: const Text('Email App'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {
+              Navigator.pushNamed(context, '/profile');
+            },
           ),
+        ],
+      ),
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _screens,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.inbox), label: 'Hộp thư đến'),
           BottomNavigationBarItem(icon: Icon(Icons.send), label: 'Đã gửi'),
           BottomNavigationBarItem(icon: Icon(Icons.drafts), label: 'Bản nháp'),
           BottomNavigationBarItem(icon: Icon(Icons.delete), label: 'Thùng rác'),
         ],
-        currentIndex: _selectedIndex,
-        selectedItemColor: Colors.blue,
-        unselectedItemColor: Colors.grey,
-        onTap: _onItemTapped,
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.pushNamed(context, '/compose');
+        },
+        tooltip: 'Soạn thư mới',
+        child: const Icon(Icons.edit),
       ),
     );
   }

--- a/lib/screens/sent/sent_screen.dart
+++ b/lib/screens/sent/sent_screen.dart
@@ -1,14 +1,65 @@
 import 'package:flutter/material.dart';
+import 'package:email_application/models/email_data.dart';
+import 'package:email_application/widgets/email_list_item.dart';
+import 'package:email_application/screens/emails/view_email_screen.dart';
 
 class SentScreen extends StatelessWidget {
   const SentScreen({super.key});
 
+  static final List<EmailData> mockEmails = [
+    EmailData(
+      id: '1',
+      senderName: 'Bạn',
+      subject: 'Gửi báo cáo',
+      previewText: 'Mình vừa gửi báo cáo tuần này...',
+      body: 'Nội dung đầy đủ: Báo cáo tuần này đã được hoàn thành và gửi đi.',
+      time: '10:00 AM',
+      isRead: true,
+      to: [{'displayName': 'Nguyễn Văn A'}],
+    ),
+    EmailData(
+      id: '2',
+      senderName: 'Bạn',
+      subject: 'Hẹn gặp',
+      previewText: 'Cuối tuần này bạn rảnh không?',
+      body: 'Nội dung đầy đủ: Mình muốn hẹn gặp để bàn về dự án.',
+      time: 'Hôm qua',
+      isRead: true,
+      to: [{'displayName': 'Trần Thị B'}],
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text(
-        'Đã gửi',
-        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Đã gửi'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ListView.builder(
+          itemCount: mockEmails.length,
+          itemBuilder: (context, index) {
+            final email = mockEmails[index];
+            return InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ViewEmailScreen(emailData: email),
+                  ),
+                );
+              },
+              child: EmailListItem(
+                senderName: email.senderName,
+                subject: email.subject,
+                previewText: email.previewText,
+                time: email.time,
+                isRead: email.isRead,
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/trash/trash_screen.dart
+++ b/lib/screens/trash/trash_screen.dart
@@ -1,14 +1,65 @@
 import 'package:flutter/material.dart';
+import 'package:email_application/models/email_data.dart';
+import 'package:email_application/widgets/email_list_item.dart';
+import 'package:email_application/screens/emails/view_email_screen.dart';
 
 class TrashScreen extends StatelessWidget {
   const TrashScreen({super.key});
 
+  static final List<EmailData> mockEmails = [
+    EmailData(
+      id: '1',
+      senderName: 'Nguyễn Văn A',
+      subject: 'Quảng cáo sản phẩm',
+      previewText: 'Ưu đãi đặc biệt dành cho bạn...',
+      body: 'Nội dung đầy đủ: Đây là email quảng cáo sản phẩm mới, đã bị xóa.',
+      time: 'Thứ Ba',
+      isRead: true,
+      to: [{'displayName': 'Bạn'}],
+    ),
+    EmailData(
+      id: '2',
+      senderName: 'Trần Thị B',
+      subject: 'Nhắc nhở cuộc họp',
+      previewText: 'Đừng quên cuộc họp ngày mai...',
+      body: 'Nội dung đầy đủ: Nhắc nhở về cuộc họp ngày mai, đã bị xóa nhầm.',
+      time: 'Hôm qua',
+      isRead: false,
+      to: [{'displayName': 'Bạn'}],
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text(
-        'Thùng rác',
-        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Thùng rác'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ListView.builder(
+          itemCount: mockEmails.length,
+          itemBuilder: (context, index) {
+            final email = mockEmails[index];
+            return InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ViewEmailScreen(emailData: email),
+                  ),
+                );
+              },
+              child: EmailListItem(
+                senderName: email.senderName,
+                subject: email.subject,
+                previewText: email.previewText,
+                time: email.time,
+                isRead: email.isRead,
+              ),
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
Hoàn thành hiển thị danh sách email giả trong InboxScreen, SentScreen, DraftsScreen, và TrashScreen sử dụng EmailListItem. Tạo ViewEmailScreen để hiển thị chi tiết email và thiết lập điều hướng từ các màn hình. Thêm FloatingActionButton trên MainScreen để mở ComposeEmailScreen. Sẵn sàng tích hợp dữ liệu thật từ Firebase trong buổi chiều.